### PR TITLE
Add content sanitization using DOMPurify

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -310,6 +310,11 @@ export interface MDXEditorProps {
    * A custom lexical theme to use for the editor.
    */
   lexicalTheme?: EditorThemeClasses
+
+  /**
+   * Enable or disable content sanitization.
+   */
+  sanitizeContent?: boolean
 }
 
 /**
@@ -335,7 +340,8 @@ export const MDXEditor = React.forwardRef<MDXEditorMethods, MDXEditorProps>((pro
           onError: props.onError ?? noop,
           translation: props.translation ?? defaultTranslation,
           trim: props.trim ?? true,
-          lexicalTheme: props.lexicalTheme
+          lexicalTheme: props.lexicalTheme,
+          sanitizeContent: props.sanitizeContent ?? false
         }),
         ...(props.plugins ?? [])
       ]}

--- a/src/exportMarkdownFromLexical.ts
+++ b/src/exportMarkdownFromLexical.ts
@@ -6,6 +6,7 @@ import type { JsxComponentDescriptor } from './plugins/jsx'
 import { isMdastHTMLNode } from './plugins/core/MdastHTMLNode'
 import { mergeStyleAttributes } from './utils/mergeStyleAttributes'
 import { ImportStatement } from './importMarkdownToLexical'
+import DOMPurify from 'dompurify'
 
 export type { Options as ToMarkdownOptions } from 'mdast-util-to-markdown'
 
@@ -390,6 +391,10 @@ export interface ExportMarkdownFromLexicalOptions extends ExportLexicalTreeOptio
    * The options to pass to `toMarkdown`
    */
   toMarkdownOptions: ToMarkdownOptions
+  /**
+   * Enable or disable content sanitization.
+   */
+  sanitizeContent?: boolean
 }
 
 /**
@@ -412,6 +417,10 @@ export interface LexicalConvertOptions {
   toMarkdownOptions?: ToMarkdownOptions
 }
 
+function sanitizeMarkdown(markdown: string): string {
+  return DOMPurify.sanitize(markdown, { ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'code', 'pre', 'blockquote', 'ul', 'ol', 'li', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'hr', 'br', 'div', 'span'], ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'class', 'id', 'style'] })
+}
+
 /**
  * @internal
  */
@@ -421,12 +430,12 @@ export function exportMarkdownFromLexical({
   toMarkdownExtensions,
   visitors,
   jsxComponentDescriptors,
-  jsxIsAvailable
+  jsxIsAvailable,
+  sanitizeContent = false
 }: ExportMarkdownFromLexicalOptions): string {
-  return (
-    toMarkdown(exportLexicalTreeToMdast({ root, visitors, jsxComponentDescriptors, jsxIsAvailable }), {
-      extensions: toMarkdownExtensions,
-      ...toMarkdownOptions
-    }) + '\n'
-  )
+  const markdown = toMarkdown(exportLexicalTreeToMdast({ root, visitors, jsxComponentDescriptors, jsxIsAvailable }), {
+    extensions: toMarkdownExtensions,
+    ...toMarkdownOptions
+  }) + '\n'
+  return sanitizeContent ? sanitizeMarkdown(markdown) : markdown
 }

--- a/src/importMarkdownToLexical.ts
+++ b/src/importMarkdownToLexical.ts
@@ -9,6 +9,7 @@ import { FORMAT } from './FormatConstants'
 import { CodeBlockEditorDescriptor } from './plugins/codeblock'
 import { DirectiveDescriptor } from './plugins/directives'
 import { JsxComponentDescriptor } from './plugins/jsx'
+import DOMPurify from 'dompurify'
 
 export interface ImportStatement {
   source: string
@@ -137,6 +138,7 @@ export interface MarkdownParseOptions extends Omit<MdastTreeImportOptions, 'mdas
   markdown: string
   syntaxExtensions: NonNullable<ParseOptions['extensions']>
   mdastExtensions: MdastExtensions
+  sanitizeContent?: boolean
 }
 
 /**
@@ -202,6 +204,10 @@ function gatherMetadata(mdastNode: Mdast.RootContent | Mdast.Root): MetaData {
   }
 }
 
+function sanitizeMarkdown(markdown: string): string {
+  return DOMPurify.sanitize(markdown, { ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'code', 'pre', 'blockquote', 'ul', 'ol', 'li', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'hr', 'br', 'div', 'span'], ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'class', 'id', 'style'] })
+}
+
 /** @internal */
 export function importMarkdownToLexical({
   root,
@@ -209,11 +215,12 @@ export function importMarkdownToLexical({
   visitors,
   syntaxExtensions,
   mdastExtensions,
+  sanitizeContent = false,
   ...descriptors
 }: MarkdownParseOptions): void {
   let mdastRoot: Mdast.Root
   try {
-    mdastRoot = fromMarkdown(markdown, {
+    mdastRoot = fromMarkdown(sanitizeContent ? sanitizeMarkdown(markdown) : markdown, {
       extensions: syntaxExtensions,
       mdastExtensions
     })

--- a/src/mdastUtilHtmlComment.ts
+++ b/src/mdastUtilHtmlComment.ts
@@ -1,9 +1,8 @@
-// typed version of https://github.com/slorber/remark-comment/blob/slorber/multiline-comment-bug/index.js
-//
 import type { Handle, Transform } from 'mdast-util-from-markdown'
 import { factorySpace } from 'micromark-factory-space'
 import { markdownLineEnding } from 'micromark-util-character'
 import { codes, types } from 'micromark-util-symbol'
+import DOMPurify from 'dompurify'
 
 import type { Code, Extension, Tokenizer } from 'micromark-util-types'
 
@@ -45,7 +44,7 @@ export function commentFromMarkdown(_options: { ast?: boolean }): Partial<Config
     },
     exit: {
       comment(token) {
-        const text = this.resume()
+        const text = sanitizeHtmlComment(this.resume())
         if (_options.ast) {
           this.enter(
             {
@@ -61,6 +60,10 @@ export function commentFromMarkdown(_options: { ast?: boolean }): Partial<Config
       }
     }
   }
+}
+
+function sanitizeHtmlComment(comment: string): string {
+  return DOMPurify.sanitize(comment, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })
 }
 
 const tokenize: Tokenizer = (effects, ok, nok) => {


### PR DESCRIPTION
* **exportMarkdownFromLexical.ts**
  - Add `sanitizeMarkdown` function to sanitize markdown content.
  - Modify `exportMarkdownFromLexical` function to call `sanitizeMarkdown` if `sanitizeContent` flag is true.
  - Add `sanitizeContent` flag to `ExportMarkdownFromLexicalOptions`.

* **importMarkdownToLexical.ts**
  - Add `sanitizeMarkdown` function to sanitize markdown content.
  - Modify `importMarkdownToLexical` function to call `sanitizeMarkdown` if `sanitizeContent` flag is true.
  - Add `sanitizeContent` flag to `MarkdownParseOptions`.

* **mdastUtilHtmlComment.ts**
  - Add `sanitizeHtmlComment` function to sanitize HTML comments.
  - Modify `commentFromMarkdown` function to call `sanitizeHtmlComment`.

* **MDXEditor.tsx**
  - Add `sanitizeContent` prop to enable or disable content sanitization.
  - Modify `MDXEditor` component to use `sanitizeContent` prop when calling `exportMarkdownFromLexical` and `importMarkdownToLexical`.